### PR TITLE
feat: add AuthorizationClient interface for testable OAuth contracts

### DIFF
--- a/src/androidMain/kotlin/dev/yet300/appauth/AuthorizationService.kt
+++ b/src/androidMain/kotlin/dev/yet300/appauth/AuthorizationService.kt
@@ -21,7 +21,7 @@ import kotlin.coroutines.suspendCoroutine
 
 actual class AuthorizationService private constructor(
     private val android: net.openid.appauth.AuthorizationService,
-) {
+) : AuthorizationClient {
     actual constructor(context: () -> AuthorizationServiceContext) : this(
         net.openid.appauth.AuthorizationService(
             context(),
@@ -43,7 +43,7 @@ actual class AuthorizationService private constructor(
 
     private lateinit var launcher: ActivityResultLauncher<Intent>
 
-    actual suspend fun performAuthorizationRequest(request: AuthorizationRequest): AuthorizationResponse {
+    actual override suspend fun performAuthorizationRequest(request: AuthorizationRequest): AuthorizationResponse {
         // Show the request details
         Napier.d("📤 Starting AuthorizationRequest:\n$request")
         // if a previous request is still pending then wait for it to finish
@@ -71,7 +71,7 @@ actual class AuthorizationService private constructor(
         }
     }
 
-    actual suspend fun performEndSessionRequest(request: EndSessionRequest) {
+    actual override suspend fun performEndSessionRequest(request: EndSessionRequest) {
         // if a previous request is still pending then wait for it to finish
         // Show the request details
         Napier.d("📤 Starting EndSessionRequest:\n$request")
@@ -101,7 +101,7 @@ actual class AuthorizationService private constructor(
         }
     }
 
-    actual suspend fun performTokenRequest(request: TokenRequest): TokenResponse =
+    actual override suspend fun performTokenRequest(request: TokenRequest): TokenResponse =
         suspendCoroutine { cont ->
             Napier.d("🔐 Starting performTokenRequest")
             Napier.d("📤 TokenRequest:\n$request")
@@ -118,7 +118,7 @@ actual class AuthorizationService private constructor(
             }
         }
 
-    actual suspend fun performRevokeTokenRequest(request: RevokeTokenRequest) =
+    actual override suspend fun performRevokeTokenRequest(request: RevokeTokenRequest) =
         withContext(Dispatchers.IO) {
             val endpoint =
                 request.config.revocationEndpoint

--- a/src/commonMain/kotlin/dev/yet300/appauth/AuthorizationClient.kt
+++ b/src/commonMain/kotlin/dev/yet300/appauth/AuthorizationClient.kt
@@ -1,0 +1,18 @@
+package dev.yet300.appauth
+
+/**
+ * Common contract for OAuth / OIDC operations exposed by [AuthorizationService].
+ *
+ * Apps should depend on this interface (not the platform [AuthorizationService] class)
+ * so token refresh, revocation, and interactive login flows can be faked in
+ * `commonTest` without constructing a platform service.
+ */
+interface AuthorizationClient {
+    suspend fun performAuthorizationRequest(request: AuthorizationRequest): AuthorizationResponse
+
+    suspend fun performEndSessionRequest(request: EndSessionRequest)
+
+    suspend fun performTokenRequest(request: TokenRequest): TokenResponse
+
+    suspend fun performRevokeTokenRequest(request: RevokeTokenRequest)
+}

--- a/src/commonMain/kotlin/dev/yet300/appauth/commonMain.kt
+++ b/src/commonMain/kotlin/dev/yet300/appauth/commonMain.kt
@@ -11,7 +11,7 @@ expect class AuthorizationServiceContext
  */
 expect class AuthorizationService(
     context: () -> AuthorizationServiceContext,
-) {
+) : AuthorizationClient {
     /**
      * Performs an authorization request to the authorization server.
      * This typically involves opening a browser or a custom tab for the user to sign in.
@@ -20,7 +20,7 @@ expect class AuthorizationService(
      * @return An [AuthorizationResponse] containing the authorization code and other details.
      * @throws AuthorizationException if the authorization flow fails.
      */
-    suspend fun performAuthorizationRequest(request: AuthorizationRequest): AuthorizationResponse
+    suspend override fun performAuthorizationRequest(request: AuthorizationRequest): AuthorizationResponse
 
     /**
      * Performs an end-session request to the authorization server to log the user out.
@@ -29,7 +29,7 @@ expect class AuthorizationService(
      * @param request The [EndSessionRequest] containing details for the logout flow.
      * @throws AuthorizationException if the end-session flow fails.
      */
-    suspend fun performEndSessionRequest(request: EndSessionRequest)
+    suspend override fun performEndSessionRequest(request: EndSessionRequest)
 
     /**
      * Performs a token request to exchange an authorization code or refresh token for new tokens.
@@ -38,7 +38,7 @@ expect class AuthorizationService(
      * @return A [TokenResponse] containing the new access, refresh, and ID tokens.
      * @throws AuthorizationException if the token exchange fails.
      */
-    suspend fun performTokenRequest(request: TokenRequest): TokenResponse
+    suspend override fun performTokenRequest(request: TokenRequest): TokenResponse
 
     /**
      * Performs a token revocation request as per RFC 7009.
@@ -47,7 +47,7 @@ expect class AuthorizationService(
      * @param request The [RevokeTokenRequest] containing the token to be revoked.
      * @throws AuthorizationException if the revocation fails.
      */
-    suspend fun performRevokeTokenRequest(request: RevokeTokenRequest)
+    suspend override fun performRevokeTokenRequest(request: RevokeTokenRequest)
 }
 
 /**

--- a/src/commonTest/kotlin/dev/yet300/appauth/AuthorizationClientContractTest.kt
+++ b/src/commonTest/kotlin/dev/yet300/appauth/AuthorizationClientContractTest.kt
@@ -1,0 +1,29 @@
+package dev.yet300.appauth
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+class AuthorizationClientContractTest {
+    private class FakeAuthorizationClient : AuthorizationClient {
+        override suspend fun performAuthorizationRequest(request: AuthorizationRequest): AuthorizationResponse {
+            error("not stubbed")
+        }
+
+        override suspend fun performEndSessionRequest(request: EndSessionRequest) {
+            error("not stubbed")
+        }
+
+        override suspend fun performTokenRequest(request: TokenRequest): TokenResponse {
+            error("not stubbed")
+        }
+
+        override suspend fun performRevokeTokenRequest(request: RevokeTokenRequest) = Unit
+    }
+
+    @Test
+    fun `AuthorizationClient can be implemented in commonTest without a platform AuthorizationService`() =
+        runTest {
+            assertNotNull(FakeAuthorizationClient())
+        }
+}

--- a/src/iosMain/kotlin/dev/yet300/appauth/AuthorizationService.kt
+++ b/src/iosMain/kotlin/dev/yet300/appauth/AuthorizationService.kt
@@ -33,12 +33,12 @@ internal fun String.base64Encoded(): String {
 @OptIn(ExperimentalForeignApi::class)
 actual class AuthorizationService actual constructor(
     private val context: () -> AuthorizationServiceContext,
-) {
+) : AuthorizationClient {
     private var session: OIDExternalUserAgentSessionProtocol? = null
 
     fun resumeExternalUserAgentFlow(url: NSURL): Boolean = session?.resumeExternalUserAgentFlowWithURL(url) == true
 
-    actual suspend fun performAuthorizationRequest(request: AuthorizationRequest): AuthorizationResponse =
+    actual override suspend fun performAuthorizationRequest(request: AuthorizationRequest): AuthorizationResponse =
         withContext(Dispatchers.Main) {
             Napier.d("🔐 Starting iOS performAuthorizationRequest")
             Napier.d("📤 AuthorizationRequest:\n$request")
@@ -70,7 +70,7 @@ actual class AuthorizationService actual constructor(
             }
         }
 
-    actual suspend fun performEndSessionRequest(request: EndSessionRequest) =
+    actual override suspend fun performEndSessionRequest(request: EndSessionRequest) =
         withContext(Dispatchers.Main) {
             Napier.d("🔐 Starting iOS performEndSessionRequest")
             Napier.d("📤 EndSessionRequest:\n$request")
@@ -102,7 +102,7 @@ actual class AuthorizationService actual constructor(
             }
         }
 
-    actual suspend fun performTokenRequest(request: TokenRequest): TokenResponse =
+    actual override suspend fun performTokenRequest(request: TokenRequest): TokenResponse =
         withContext(Dispatchers.Main) {
             Napier.d("🔐 Starting iOS performTokenRequest")
             Napier.d("📤 TokenRequest:\n$request")
@@ -128,7 +128,7 @@ actual class AuthorizationService actual constructor(
             }
         }
 
-    actual suspend fun performRevokeTokenRequest(request: RevokeTokenRequest) {
+    actual override suspend fun performRevokeTokenRequest(request: RevokeTokenRequest) {
         val endpoint =
             request.config.revocationEndpoint
                 ?: throw AuthorizationException("Revocation endpoint not found in configuration.")

--- a/src/jsMain/kotlin/dev/yet300/appauth/JsMain.kt
+++ b/src/jsMain/kotlin/dev/yet300/appauth/JsMain.kt
@@ -69,20 +69,20 @@ actual class TokenResponse {
 
 actual class AuthorizationService actual constructor(
     context: () -> AuthorizationServiceContext,
-) {
-    actual suspend fun performAuthorizationRequest(request: AuthorizationRequest): AuthorizationResponse {
+) : AuthorizationClient {
+    actual override suspend fun performAuthorizationRequest(request: AuthorizationRequest): AuthorizationResponse {
         TODO("Not yet implemented")
     }
 
-    actual suspend fun performTokenRequest(request: TokenRequest): TokenResponse {
+    actual override suspend fun performTokenRequest(request: TokenRequest): TokenResponse {
         TODO("Not yet implemented")
     }
 
-    actual suspend fun performEndSessionRequest(request: EndSessionRequest) {
+    actual override suspend fun performEndSessionRequest(request: EndSessionRequest) {
         TODO("Not yet implemented")
     }
 
-    actual suspend fun performRevokeTokenRequest(request: RevokeTokenRequest) {
+    actual override suspend fun performRevokeTokenRequest(request: RevokeTokenRequest) {
         TODO("Not yet implemented")
     }
 }


### PR DESCRIPTION
## Summary

Adds a common `AuthorizationClient` interface implemented by the platform `AuthorizationService` expect/actual class.

Apps can depend on the interface instead of the concrete platform service, enabling fakes in `commonTest` without constructing Activity/UIViewController-bound services.

## Changes

- New `AuthorizationClient` interface with the four OAuth operations (authorize, end session, token exchange, revoke)
- `AuthorizationService` now implements `AuthorizationClient` on all targets (Android, iOS, JS)
- Contract test proving the interface can be implemented in `commonTest`

## Motivation

Consumer apps (e.g. secret-santa-mobile) currently wrap AppAuth in app-specific seams to unit-test token refresh and logout ordering. This interface belongs in the library.

## Test plan

- [x] `./gradlew compileDebugKotlinAndroid compileKotlinIosSimulatorArm64`
- [ ] `./gradlew test` (CI)

Part of a series:
- This PR (foundation)
- Follow-up: `appauth-kotlin-testing` fake client
- Follow-up: `AuthorizationServiceConfigurationProvider`
- Follow-up: `TokenOperations` / `InteractiveAuthorization` split

Made with [Cursor](https://cursor.com)