### PR TITLE
feat: split AuthorizationClient into headless and interactive interfaces

### DIFF
--- a/src/commonMain/kotlin/dev/yet300/appauth/AuthorizationClient.kt
+++ b/src/commonMain/kotlin/dev/yet300/appauth/AuthorizationClient.kt
@@ -6,13 +6,7 @@ package dev.yet300.appauth
  * Apps should depend on this interface (not the platform [AuthorizationService] class)
  * so token refresh, revocation, and interactive login flows can be faked in
  * `commonTest` without constructing a platform service.
+ *
+ * Composed of [TokenOperations] (headless) and [InteractiveAuthorization] (UI-bound).
  */
-interface AuthorizationClient {
-    suspend fun performAuthorizationRequest(request: AuthorizationRequest): AuthorizationResponse
-
-    suspend fun performEndSessionRequest(request: EndSessionRequest)
-
-    suspend fun performTokenRequest(request: TokenRequest): TokenResponse
-
-    suspend fun performRevokeTokenRequest(request: RevokeTokenRequest)
-}
+interface AuthorizationClient : TokenOperations, InteractiveAuthorization

--- a/src/commonMain/kotlin/dev/yet300/appauth/InteractiveAuthorization.kt
+++ b/src/commonMain/kotlin/dev/yet300/appauth/InteractiveAuthorization.kt
@@ -1,0 +1,10 @@
+package dev.yet300.appauth
+
+/**
+ * Interactive OAuth flows that require a browser, custom tab, or platform UI context.
+ */
+interface InteractiveAuthorization {
+    suspend fun performAuthorizationRequest(request: AuthorizationRequest): AuthorizationResponse
+
+    suspend fun performEndSessionRequest(request: EndSessionRequest)
+}

--- a/src/commonMain/kotlin/dev/yet300/appauth/TokenOperations.kt
+++ b/src/commonMain/kotlin/dev/yet300/appauth/TokenOperations.kt
@@ -1,0 +1,13 @@
+package dev.yet300.appauth
+
+/**
+ * Headless OAuth token operations that do not require a browser or platform UI context.
+ *
+ * Token refresh and revocation can run from background coroutines and are the primary
+ * targets for unit tests in consumer apps.
+ */
+interface TokenOperations {
+    suspend fun performTokenRequest(request: TokenRequest): TokenResponse
+
+    suspend fun performRevokeTokenRequest(request: RevokeTokenRequest)
+}

--- a/src/commonTest/kotlin/dev/yet300/appauth/TokenOperationsContractTest.kt
+++ b/src/commonTest/kotlin/dev/yet300/appauth/TokenOperationsContractTest.kt
@@ -1,0 +1,21 @@
+package dev.yet300.appauth
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+class TokenOperationsContractTest {
+
+    private class HeadlessFake : TokenOperations {
+        override suspend fun performTokenRequest(request: TokenRequest): TokenResponse {
+            error("not stubbed")
+        }
+
+        override suspend fun performRevokeTokenRequest(request: RevokeTokenRequest) = Unit
+    }
+
+    @Test
+    fun `TokenOperations can be faked independently of interactive authorization`() = runTest {
+        assertNotNull(HeadlessFake())
+    }
+}


### PR DESCRIPTION
## Summary

Splits the OAuth contract into headless token operations vs interactive browser flows.

## Changes

- `TokenOperations` — `performTokenRequest`, `performRevokeTokenRequest` (no UI context)
- `InteractiveAuthorization` — `performAuthorizationRequest`, `performEndSessionRequest`
- `AuthorizationClient` now extends both (unchanged surface for `AuthorizationService`)

## Motivation

Consumer apps test token refresh and logout frequently but rarely need to mock browser login in unit tests. Depending on `TokenOperations` alone documents intent and allows smaller fakes.

## Test plan

- [x] `./gradlew compileDebugKotlinAndroid`

**Depends on:** #6

Made with [Cursor](https://cursor.com)