### PR TITLE
feat: add appauth-kotlin-testing module with FakeAuthorizationClient

### DIFF
--- a/appauth-kotlin-testing/README.md
+++ b/appauth-kotlin-testing/README.md
@@ -1,0 +1,19 @@
+## Testing
+
+For unit tests, add the testing artifact to `commonTest`:
+
+```kotlin
+commonTest.dependencies {
+    implementation("io.github.yet300:appauth-kotlin-testing:0.1.2")
+}
+```
+
+Use [FakeAuthorizationClient](appauth-kotlin-testing/src/commonMain/kotlin/dev/yet300/appauth/testing/FakeAuthorizationClient.kt) to stub OAuth operations without a platform `AuthorizationService`:
+
+```kotlin
+val oauth = FakeAuthorizationClient()
+oauth.onTokenRequest = { request -> /* return TokenResponse */ }
+oauth.onRevokeTokenRequest = { /* record revocation */ }
+```
+
+Depends on [AuthorizationClient](src/commonMain/kotlin/dev/yet300/appauth/AuthorizationClient.kt) (see PR #6).

--- a/appauth-kotlin-testing/build.gradle.kts
+++ b/appauth-kotlin-testing/build.gradle.kts
@@ -1,0 +1,67 @@
+plugins {
+    kotlin("multiplatform") version "2.3.0"
+    id("com.android.library")
+    id("com.vanniktech.maven.publish") version "0.30.0"
+}
+
+val MODULE_PACKAGE_NAME: String by project
+val MODULE_VERSION_NUMBER: String by project
+
+group = MODULE_PACKAGE_NAME
+version = MODULE_VERSION_NUMBER
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+kotlin {
+    androidTarget {
+        publishLibraryVariants("release")
+    }
+
+    js(IR) {
+        browser { }
+    }
+
+    listOf(
+        iosX64(),
+        iosArm64(),
+        iosSimulatorArm64(),
+    ).forEach { iosTarget ->
+        iosTarget.binaries.framework {
+            baseName = "appauth_kotlin_testing"
+            isStatic = true
+        }
+    }
+
+    sourceSets {
+        commonMain.dependencies {
+            api(project(":"))
+        }
+
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+            implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+        }
+    }
+}
+
+android {
+    compileSdk = 36
+    namespace = "$MODULE_PACKAGE_NAME.appauth.testing"
+    defaultConfig {
+        minSdk = 23
+    }
+}
+
+mavenPublishing {
+    publishToMavenCentral(com.vanniktech.maven.publish.SonatypeHost.CENTRAL_PORTAL)
+    signAllPublications()
+    coordinates(MODULE_PACKAGE_NAME, "appauth-kotlin-testing", MODULE_VERSION_NUMBER)
+    pom {
+        name.set("appauth-kotlin-testing")
+        description.set("Test fakes and helpers for appauth-kotlin")
+        url.set("https://github.com/yet300/AppAuth-Kotlin")
+    }
+}

--- a/appauth-kotlin-testing/src/commonMain/kotlin/dev/yet300/appauth/testing/FakeAuthorizationClient.kt
+++ b/appauth-kotlin-testing/src/commonMain/kotlin/dev/yet300/appauth/testing/FakeAuthorizationClient.kt
@@ -1,0 +1,54 @@
+package dev.yet300.appauth.testing
+
+import dev.yet300.appauth.AuthorizationClient
+import dev.yet300.appauth.AuthorizationRequest
+import dev.yet300.appauth.AuthorizationResponse
+import dev.yet300.appauth.EndSessionRequest
+import dev.yet300.appauth.RevokeTokenRequest
+import dev.yet300.appauth.TokenRequest
+import dev.yet300.appauth.TokenResponse
+
+/**
+ * Configurable fake [AuthorizationClient] for unit tests.
+ *
+ * Stub responses via the `on*` lambdas. By default, token and authorization
+ * handlers throw — override them in tests that need return values.
+ *
+ * All invocations are recorded in the public `*Calls` lists for ordering assertions
+ * (e.g. revoke-before-clear in logout tests).
+ */
+class FakeAuthorizationClient : AuthorizationClient {
+    var onAuthorizationRequest: suspend (AuthorizationRequest) -> AuthorizationResponse = {
+        error("performAuthorizationRequest not stubbed")
+    }
+    var onEndSessionRequest: suspend (EndSessionRequest) -> Unit = {}
+    var onTokenRequest: suspend (TokenRequest) -> TokenResponse = {
+        error("performTokenRequest not stubbed")
+    }
+    var onRevokeTokenRequest: suspend (RevokeTokenRequest) -> Unit = {}
+
+    val authorizationCalls = mutableListOf<AuthorizationRequest>()
+    val endSessionCalls = mutableListOf<EndSessionRequest>()
+    val tokenCalls = mutableListOf<TokenRequest>()
+    val revokeCalls = mutableListOf<RevokeTokenRequest>()
+
+    override suspend fun performAuthorizationRequest(request: AuthorizationRequest): AuthorizationResponse {
+        authorizationCalls += request
+        return onAuthorizationRequest(request)
+    }
+
+    override suspend fun performEndSessionRequest(request: EndSessionRequest) {
+        endSessionCalls += request
+        onEndSessionRequest(request)
+    }
+
+    override suspend fun performTokenRequest(request: TokenRequest): TokenResponse {
+        tokenCalls += request
+        return onTokenRequest(request)
+    }
+
+    override suspend fun performRevokeTokenRequest(request: RevokeTokenRequest) {
+        revokeCalls += request
+        onRevokeTokenRequest(request)
+    }
+}

--- a/appauth-kotlin-testing/src/commonTest/kotlin/dev/yet300/appauth/testing/FakeAuthorizationClientTest.kt
+++ b/appauth-kotlin-testing/src/commonTest/kotlin/dev/yet300/appauth/testing/FakeAuthorizationClientTest.kt
@@ -1,0 +1,17 @@
+package dev.yet300.appauth.testing
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FakeAuthorizationClientTest {
+
+    @Test
+    fun `FakeAuthorizationClient should start with empty call logs`() {
+        val fake = FakeAuthorizationClient()
+
+        assertEquals(0, fake.authorizationCalls.size)
+        assertEquals(0, fake.endSessionCalls.size)
+        assertEquals(0, fake.tokenCalls.size)
+        assertEquals(0, fake.revokeCalls.size)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,3 +13,4 @@ pluginManagement {
     }
 }
 rootProject.name = "appauth-kotlin"
+include(":appauth-kotlin-testing")


### PR DESCRIPTION
## Summary

Adds a published testing artifact so consumer apps can fake OAuth operations in `commonTest` without app-specific wrapper interfaces.

## Changes

- New Gradle subproject `:appauth-kotlin-testing`
- Maven coordinates: `io.github.yet300:appauth-kotlin-testing`
- `FakeAuthorizationClient` — configurable stubs + call recording (`authorizationCalls`, `tokenCalls`, `revokeCalls`, …)
- Module README with usage snippet

## Usage (consumer apps)

```kotlin
// build.gradle.kts
commonTest.dependencies {
    implementation("io.github.yet300:appauth-kotlin-testing:0.1.2")
}

// test
val oauth = FakeAuthorizationClient()
oauth.onRevokeTokenRequest = { /* ... */ }
// assert ordering via oauth.revokeCalls
```

This replaces per-app seams like secret-santa's `OAuthClient`.

## Test plan

- [x] `./gradlew :appauth-kotlin-testing:compileDebugKotlinAndroid`

**Depends on:** #6

## Follow-up (optional)

- `createTestTokenResponse()` helper for stubbing token refresh returns in commonTest
- Move `StaticAuthorizationServiceConfigurationProvider` here once #7 lands

Made with [Cursor](https://cursor.com)